### PR TITLE
Add ZIP as runtime dependency. Fix #6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ ARG RUNTIME_DEPENDENCIES="\
 	php \
 	php-cli \
 	php-mysql \
+	zip \
 	vlc-data"
 
 # install packages


### PR DESCRIPTION
Add `zip` as dependency so that we can export events also as zip and not only as tar.