### PR TITLE
Run zmupdate.pl before starting up.

### DIFF
--- a/root/etc/services.d/zoneminder/run
+++ b/root/etc/services.d/zoneminder/run
@@ -5,6 +5,9 @@ sleep 1
 done
 
 s6-setuidgid abc \
+        /usr/bin/zmupdate.pl -u root -p
+
+s6-setuidgid abc \
 	/usr/bin/zmpkg.pl start
 
 exec \


### PR DESCRIPTION
`zmupdate.pl -u root -p` is called before starting `zmpkg.pl start`.

Closes #17 
