### PR TITLE
Make sure /var/cache/zoneminder exists.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,7 @@ RUN \
  git submodule update --init --recursive && \
  cmake \
 	-DCMAKE_INSTALL_PREFIX=/usr \
+	-DZM_CACHEDIR=/var/cache/zoneminder \
 	-DZM_CGIDIR=/usr/share/webapps/zoneminder/cgi-bin \
 	-DZM_CONFIG_DIR=/etc/zm \
 	-DZM_CONFIG_SUBDIR=/etc/zm/conf.d \

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -10,7 +10,8 @@ mkdir -p \
 	/config/{apache,log/mysql,log/zoneminder,mysql,zoneminder} \
 	/data/{zoneminder/events,zoneminder/exports,zoneminder/images,zoneminder/sounds} \
 	/var/run/mysqld \
-	/var/run/zoneminder
+	/var/run/zoneminder \
+	/var/cache/zoneminder
 
 
 # copy apache config
@@ -50,4 +51,5 @@ chown -R abc:abc \
 chmod -R 777 \
 	/var/lib/apache2 \
 	/var/run/mysqld \
-	/var/run/zoneminder
+	/var/run/zoneminder \
+	/var/cache/zoneminder


### PR DESCRIPTION
Zoneminder added cache dirs, but they were not created in the container.

Fixes #16 and #13 

Note that this currently only works when using the `/zm` alias to visit the page. This is due to how the apache.conf file is setup upstream. I guess it would make sense to override this file for our configuration.